### PR TITLE
build: upgrade to Spring Boot 4.1.0 (Spring Framework 7, Java 17)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-java@v5
         with:
           distribution: corretto
-          java-version: "11"
+          java-version: "17"
       - uses: github/codeql-action/init@v4
         with:
           languages: java-kotlin

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -27,11 +27,11 @@ jobs:
         uses: actions/checkout@v7
 
 #      Setup Java
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: '11'
+          java-version: '17'
 
 #      Get current version from pom.xml
       - name: Get current version from pom.xml

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -14,11 +14,11 @@ jobs:
           path: ./this-repository
 
 #      Setup Java
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v5
         with:
           distribution: 'corretto'
-          java-version: 11
+          java-version: 17
 
 #     Build and Test this service
       - name: Build this project with Maven

--- a/pom.xml
+++ b/pom.xml
@@ -11,20 +11,33 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.7.13</version>
+        <version>4.1.0</version>
         <relativePath/> <!-- lookup parent from repository -->
     </parent>
 
     <properties>
-        <java.version>11</java.version>
+        <java.version>17</java.version>
         <stardog.version>[8.0.0,9.0.0)</stardog.version>
-        <springdoc.version>1.8.0</springdoc.version>
+        <springdoc.version>3.0.3</springdoc.version>
         <log4j.version>2.26.0</log4j.version>
         <google.guava.version>[32.0.0,)</google.guava.version>
         <docker.image.prefix>wseresearch</docker.image.prefix>
         <docker.image.name>memorized-question-answering-system</docker.image.name>
         <dockerfile-maven-version>1.4.13</dockerfile-maven-version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <!-- The stardog client pulls jsr305 at several versions (3.0.0/3.0.2);
+                 pin one so Spring Boot 4's stricter surefire classpath has no
+                 duplicate key. -->
+            <dependency>
+                <groupId>com.google.code.findbugs</groupId>
+                <artifactId>jsr305</artifactId>
+                <version>3.0.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <!-- https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-starter-web -->
@@ -71,10 +84,11 @@
             <artifactId>caffeine</artifactId>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-ui -->
+        <!-- Spring Boot 3+/4 uses the springdoc 2.x/3.x starter artifact (the old
+             springdoc-openapi-ui 1.x targets Spring Boot 2 / javax). -->
         <dependency>
             <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-ui</artifactId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>${springdoc.version}</version>
         </dependency>
 
@@ -124,12 +138,6 @@
             <version>4.0.5</version>
         </dependency>
 
-        <!-- https://mvnrepository.com/artifact/javax.xml.bind/jaxb-api -->
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>2.3.1</version>
-        </dependency>
     </dependencies>
 
     <repositories>

--- a/src/test/java/eu/wseresearch/memorizedquestionansweringsystem/ApplicationTests.java
+++ b/src/test/java/eu/wseresearch/memorizedquestionansweringsystem/ApplicationTests.java
@@ -4,13 +4,13 @@ import eu.wseresearch.memorizedquestionansweringsystem.triplestoreconnector.Trip
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @SpringBootTest
 class ApplicationTests {
-	@MockBean
+	@MockitoBean
 	TripleStoreConnector tripleStoreConnector;
 	MemQASystem memQASystem;
 

--- a/src/test/java/eu/wseresearch/memorizedquestionansweringsystem/controller/MemQAControllerTests.java
+++ b/src/test/java/eu/wseresearch/memorizedquestionansweringsystem/controller/MemQAControllerTests.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,7 +31,7 @@ class MemQAControllerTests {
 
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private MemQASystem mockedMemQASystem;
 
     MemQAControllerTests(


### PR DESCRIPTION
## Why

Resolves Dependabot **#24** (`spring-boot-starter-parent` 2.7.13 → 4.1.0), which fails on its own because the jump from Spring Boot 2.7 crosses **Spring Framework 5 → 7** and the **Java 11 → 17** baseline. (Same proven recipe as qanary-explanation-service #84 / Qanary_minimal #8.)

## Changes

**pom.xml**
- parent 2.7.13 → **4.1.0**; `java.version` 11 → **17**.
- `springdoc-openapi-ui` 1.8.0 (Spring Boot 2 artifact) → **`springdoc-openapi-starter-webmvc-ui` 3.0.3** (the Spring Boot 4 line). The `OpenAPI` bean already uses the swagger-core v3 API → no code change.
- Drop the stray legacy `javax.xml.bind:jaxb-api` 2.3.1 (the `jakarta.xml.bind-api` 4.0.5 stays).
- Pin transitive **jsr305 → 3.0.2** (the stardog client pulls 3.0.0 + 3.0.2) so Spring Boot 4's stricter surefire classpath has no duplicate key.

**Tests:** `@MockBean` was removed in Spring Boot 4 → migrated to Spring's `@MockitoBean`.

**CI:** bumped `setup-java` from **JDK 11 → 17** in `java-ci.yml`, `codeql.yml`, `docker-image.yml` (Spring Boot 4 needs Java 17 to build). The runtime base image moved to **25-jre** in #21 (already merged).

## Verification

`mvn package` (the exact CI command) on **JDK 17** → **BUILD SUCCESS**: 14 tests pass, jar repackaged, Docker image builds.

After this merges, #24 is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)